### PR TITLE
Adding support for "jar" as supportedExtensions. Packagecloud support…

### DIFF
--- a/src/main/java/io/packagecloud/client/Package.java
+++ b/src/main/java/io/packagecloud/client/Package.java
@@ -10,7 +10,7 @@ import java.io.File;
  */
 public class Package {
     private static Logger logger = LoggerProvider.getLogger();
-    private static String[] supportedExtensions = {"deb", "dsc", "gem", "rpm", "whl", "zip", "egg", "egg-info", "tar", "bz2", "Z", "gz"};
+    private static String[] supportedExtensions = {"deb", "dsc", "gem", "rpm", "whl", "zip", "egg", "egg-info", "tar", "bz2", "Z", "gz", "jar"};
 
     private final InputStream filestream;
     private final String repository;


### PR DESCRIPTION
The jenkins plugin is unable to upload a jar, as it is not included in this list.